### PR TITLE
Refactor providers

### DIFF
--- a/conplicity.go
+++ b/conplicity.go
@@ -49,7 +49,7 @@ func backupVolume(c *handler.Conplicity, vol *docker.Volume) (err error) {
 
 	p := providers.GetProvider(c, vol)
 	log.Infof("Using provider %v to backup %v", p.GetName(), vol.Name)
-	err = p.PrepareBackup()
+	err = providers.PrepareBackup(p)
 	util.CheckErr(err, "Failed to prepare backup for volume "+vol.Name+": %v", -1)
 	err = providers.BackupVolume(p, vol)
 	util.CheckErr(err, "Failed to backup volume "+vol.Name+": %v", -1)

--- a/providers/default.go
+++ b/providers/default.go
@@ -2,6 +2,7 @@ package providers
 
 import (
 	log "github.com/Sirupsen/logrus"
+	"github.com/fsouza/go-dockerclient"
 )
 
 // DefaultProvider implements a BaseProvider struct
@@ -18,5 +19,10 @@ func (*DefaultProvider) GetName() string {
 // PrepareBackup sets up the data before backup
 func (p *DefaultProvider) PrepareBackup() error {
 	log.Infof("Provider %v does not implement a prepare method", p.GetName())
+	return nil
+}
+
+// GetPrepareCommand returns the command to be executed before backup
+func (p *DefaultProvider) GetPrepareCommand(mount *docker.Mount) []string {
 	return nil
 }

--- a/providers/mysql.go
+++ b/providers/mysql.go
@@ -1,8 +1,6 @@
 package providers
 
 import (
-	log "github.com/Sirupsen/logrus"
-	"github.com/camptocamp/conplicity/util"
 	"github.com/fsouza/go-dockerclient"
 )
 
@@ -17,42 +15,16 @@ func (*MySQLProvider) GetName() string {
 	return "MySQL"
 }
 
-// PrepareBackup sets up MySQL data before backup
-func (p *MySQLProvider) PrepareBackup() (err error) {
-	c := p.handler.Client
-	vol := p.vol
-	log.Infof("Looking for a mysql container using this volume...")
-	containers, _ := c.ListContainers(docker.ListContainersOptions{})
-	for _, container := range containers {
-		container, err := c.InspectContainer(container.ID)
-		util.CheckErr(err, "Failed to inspect container "+container.ID+": %v", -1)
-		for _, mount := range container.Mounts {
-			if mount.Name == vol.Name {
-				log.Infof("Volume %v is used by container %v", vol.Name, container.ID)
-				log.Infof("Launch mysqldump in container %v...", container.ID)
-				exec, err := c.CreateExec(
-					docker.CreateExecOptions{
-						Container: container.ID,
-						Cmd: []string{
-							"sh",
-							"-c",
-							"mkdir -p " + mount.Destination + "/backups && mysqldump --all-databases --extended-insert --password=$MYSQL_ROOT_PASSWORD > " + mount.Destination + "/backups/all.sql",
-						},
-					},
-				)
-
-				util.CheckErr(err, "Failed to create exec", 1)
-
-				err = c.StartExec(
-					exec.ID,
-					docker.StartExecOptions{},
-				)
-
-				util.CheckErr(err, "Failed to create exec", 1)
-
-				p.backupDir = "backups"
-			}
-		}
+// GetPrepareCommand returns the command to be executed before backup
+func (p *MySQLProvider) GetPrepareCommand(mount *docker.Mount) []string {
+	return []string{
+		"sh",
+		"-c",
+		"mkdir -p " + mount.Destination + "/backups && mysqldump --all-databases --extended-insert --password=$MYSQL_ROOT_PASSWORD > " + mount.Destination + "/backups/all.sql",
 	}
-	return
+}
+
+// GetBackupDir returns the backup directory used by the provider
+func (p *MySQLProvider) GetBackupDir() string {
+	return "backups"
 }

--- a/providers/openldap.go
+++ b/providers/openldap.go
@@ -1,8 +1,6 @@
 package providers
 
 import (
-	log "github.com/Sirupsen/logrus"
-	"github.com/camptocamp/conplicity/util"
 	"github.com/fsouza/go-dockerclient"
 )
 
@@ -17,42 +15,16 @@ func (p *OpenLDAPProvider) GetName() string {
 	return "OpenLDAP"
 }
 
-// PrepareBackup sets up the OpenLDAP data before backup
-func (p *OpenLDAPProvider) PrepareBackup() (err error) {
-	c := p.handler.Client
-	vol := p.vol
-	log.Infof("Looking for an OpenLDAP container using this volume...")
-	containers, _ := c.ListContainers(docker.ListContainersOptions{})
-	for _, container := range containers {
-		container, err := c.InspectContainer(container.ID)
-		util.CheckErr(err, "Failed to inspect container "+container.ID+": %v", -1)
-		for _, mount := range container.Mounts {
-			if mount.Name == vol.Name {
-				log.Infof("Volume %v is used by container %v", vol.Name, container.ID)
-				log.Infof("Launch slapcat in container %v...", container.ID)
-				exec, err := c.CreateExec(
-					docker.CreateExecOptions{
-						Container: container.ID,
-						Cmd: []string{
-							"sh",
-							"-c",
-							"mkdir -p " + mount.Destination + "/backups && slapcat > " + mount.Destination + "/backups/all.ldif",
-						},
-					},
-				)
-
-				util.CheckErr(err, "Failed to create exec", 1)
-
-				err = c.StartExec(
-					exec.ID,
-					docker.StartExecOptions{},
-				)
-
-				util.CheckErr(err, "Failed to create exec", 1)
-
-				p.backupDir = "backups"
-			}
-		}
+// GetPrepareCommand returns the command to be executed before backup
+func (p *OpenLDAPProvider) GetPrepareCommand(mount *docker.Mount) []string {
+	return []string{
+		"sh",
+		"-c",
+		"mkdir -p " + mount.Destination + "/backups && slapcat > " + mount.Destination + "/backups/all.ldif",
 	}
-	return
+}
+
+// GetBackupDir returns the backup directory used by the provider
+func (p *OpenLDAPProvider) GetBackupDir() string {
+	return "backups"
 }

--- a/providers/provider.go
+++ b/providers/provider.go
@@ -197,8 +197,3 @@ func (p *BaseProvider) GetVolume() *docker.Volume {
 func (p *BaseProvider) GetBackupDir() string {
 	return p.backupDir
 }
-
-// GetPrepareCommand returns the command to be executed before backup
-func (p *BaseProvider) GetPrepareCommand(mount *docker.Mount) []string {
-	return nil
-}

--- a/providers/provider.go
+++ b/providers/provider.go
@@ -16,9 +16,10 @@ const labelPrefix string = "io.conplicity"
 // A Provider is an interface for providers
 type Provider interface {
 	GetName() string
+	GetPrepareCommand(*docker.Mount) []string
 	GetHandler() *handler.Conplicity
+	GetVolume() *docker.Volume
 	GetBackupDir() string
-	PrepareBackup() error
 }
 
 // BaseProvider is a struct implementing the Provider interface
@@ -55,6 +56,46 @@ func GetProvider(c *handler.Conplicity, v *docker.Volume) Provider {
 	return &DefaultProvider{
 		BaseProvider: p,
 	}
+}
+
+// PrepareBackup sets up the data before backup
+func PrepareBackup(p Provider) (err error) {
+	c := p.GetHandler()
+	vol := p.GetVolume()
+	containers, err := c.ListContainers(docker.ListContainersOptions{})
+	util.CheckErr(err, "Failed to list containers: %v", -1)
+	for _, container := range containers {
+		container, err := c.InspectContainer(container.ID)
+		util.CheckErr(err, "Failed to inspect container "+container.ID+": %v", -1)
+		for _, mount := range container.Mounts {
+			if mount.Name == vol.Name {
+				log.Infof("Volume %v is used by container %v", vol.Name, container.ID)
+
+				cmd := p.GetPrepareCommand(&mount)
+				if cmd != nil {
+
+					exec, err := c.CreateExec(
+						docker.CreateExecOptions{
+							Container: container.ID,
+							Cmd:       p.GetPrepareCommand(&mount),
+						},
+					)
+
+					util.CheckErr(err, "Failed to create exec", 1)
+
+					err = c.StartExec(
+						exec.ID,
+						docker.StartExecOptions{},
+					)
+
+					util.CheckErr(err, "Failed to create exec", 1)
+				} else {
+					log.Infof("Not executing command for volume %v in container %v", vol.Name, container.ID)
+				}
+			}
+		}
+	}
+	return
 }
 
 // BackupVolume performs the backup of the passed volume
@@ -147,7 +188,17 @@ func (p *BaseProvider) GetHandler() *handler.Conplicity {
 	return p.handler
 }
 
+// GetVolume returns the volume associated with the provider
+func (p *BaseProvider) GetVolume() *docker.Volume {
+	return p.vol
+}
+
 // GetBackupDir returns the backup directory used by the provider
 func (p *BaseProvider) GetBackupDir() string {
 	return p.backupDir
+}
+
+// GetPrepareCommand returns the command to be executed before backup
+func (p *BaseProvider) GetPrepareCommand(mount *docker.Mount) []string {
+	return nil
 }


### PR DESCRIPTION
This greatly simplifies provider logic by making `PrepareBackup()` a global method of the providers package, consuming a `Provider` interface.