### PR TITLE
add initial monitoring bits

### DIFF
--- a/conplicity.go
+++ b/conplicity.go
@@ -61,6 +61,7 @@ func backupVolume(c *handler.Conplicity, vol *docker.Volume) (err error) {
 	util.CheckErr(err, "Failed to prepare backup for volume "+vol.Name+": %v", -1)
 	err = providers.BackupVolume(p, vol)
 	util.CheckErr(err, "Failed to backup volume "+vol.Name+": %v", -1)
+	util.MonitoringStatus(vol.Name)
 	return
 }
 

--- a/util/util.go
+++ b/util/util.go
@@ -2,6 +2,9 @@ package util
 
 import (
   "os"
+  "io/ioutil"
+  "time"
+  "fmt"
 
 	log "github.com/Sirupsen/logrus"
 )
@@ -15,4 +18,16 @@ func CheckErr(err error, msg string, exit int) {
 			os.Exit(exit)
 		}
 	}
+}
+
+// MonitoringStatus generates status from backup runs, which the prometheus
+// node exporter can pick up
+func MonitoringStatus(volume string) {
+	ts := time.Now().Unix()
+	stamp := fmt.Sprint(ts)
+	labels := fmt.Sprintf("volume=\"%s\",what=\"lastruntimestamp\"", volume)
+	metric := fmt.Sprintf("conplicity{%s} %s\n", labels, stamp)
+	text := []byte(metric)
+	err := ioutil.WriteFile(volume + ".prom", text, 0644)
+	CheckErr(err, "Failed writing to monitoring file: " + volume, 1)
 }


### PR DESCRIPTION
Here's a very simplistic example of monitoring backup statuses.

I pushed this to a branch in the reference repo, so that each of us can push to it before merging.

The idea is to have the backup tasks write a bunch of metrics about their state to text files. The prometheus node exporter can then expose this data to the prometheus server. The node exporter simply grabs files matching `*.prom` from a given directory. The format is described here: https://prometheus.io/docs/instrumenting/exposition_formats/

So in the context of docker, there would be an additional set of containers in the "conplicity" stack, which share a volume with the conplicity containers.

Currently only one metric gets emitted for each volume, but I can imagine the following improvements:
 - a binary metric indicating the success or failure of the backup job, possibly with the error message in a label in case of failure
 - have the "lastruntimestamp" get updated even in the case of backup failure
 - metrics indicating the run frequency & retention time
 - a label indicating the driver used
 - a label indicating duplicity's target URL
 - metrics indicating the amount of time taken by each backup step (pulling duplicity, dumping the database, pushing to the object store)
 - metrics indicating the amount of bytes used by the backup
 - metrics grabbed from duplicity's "Backup Statistics" output

The first few ones being mandatory, the last ones nices to have.

Further than that, automatically cleaning up stale `*.prom` files and writing to temporary files before updating the `*.prom` ones seems important. More optional would be a config switch to enable/disable this feature, and a configurable target directory for the `*.prom` files.