### PR TITLE
Log as JSON (to stderr) with -j

### DIFF
--- a/handler/handler.go
+++ b/handler/handler.go
@@ -23,6 +23,7 @@ type config struct {
 	VolumesBlacklist []string `short:"b" long:"blacklist" description:"Volumes to blacklist in backups." env:"CONPLICITY_VOLUMES_BLACKLIST" env-delim:","`
 	Manpage          bool     `short:"m" long:"manpage" description:"Output manpage."`
 	NoVerify         bool     `long:"no-verify" description:"Do not verify backup." env:"CONPLICITY_NO_VERIFY"`
+	Json             bool     `short:"j" long:"json" description:"Log as JSON (to stderr)." env:"JSON_OUTPUT"`
 
 	Duplicity struct {
 		TargetURL       string `short:"u" long:"url" description:"The duplicity target URL to push to." env:"DUPLICITY_TARGET_URL"`
@@ -120,6 +121,11 @@ func (c *Conplicity) setupLoglevel() (err error) {
 		errMsg := fmt.Sprintf("Wrong log level '%v'", c.Config.Loglevel)
 		err = errors.New(errMsg)
 	}
+
+	if c.Config.Json {
+		log.SetFormatter(&log.JSONFormatter{})
+	}
+
 	return
 }
 


### PR DESCRIPTION
```
$ conplicity -j >/dev/null 
{"level":"info","msg":"Starting backup...","time":"2016-06-28T14:47:55+02:00"}
{"level":"info","msg":"Ignoring unnamed volume 393a5c6437384a4d65c53a6ec3191c4ea3c0b81994e8ff5b36482478733ee437","time":"2016-06-28T14:47:55+02:00"}
{"level":"info","msg":"Detecting provider for volume mydata","time":"2016-06-28T14:47:55+02:00"}
{"level":"info","msg":"Using provider Default to backup mydata","time":"2016-06-28T14:47:55+02:00"}
{"level":"info","msg":"ID: mydata","time":"2016-06-28T14:47:55+02:00"}
{"level":"info","msg":"Driver: local","time":"2016-06-28T14:47:55+02:00"}
{"level":"info","msg":"Mountpoint: /var/lib/docker/volumes/mydata/_data","time":"2016-06-28T14:47:55+02:00"}
{"level":"info","msg":"Creating duplicity container...","time":"2016-06-28T14:47:55+02:00"}
{"level":"info","msg":"Launching 'duplicity --full-if-older-than 15D --s3-use-new-style --ssh-options -oStrictHostKeyChecking=no --no-encryption --allow-source-mismatch --name mydata /var/lib/docker/volumes/mydata/_data/ /wrk4/mydata'...","time":"2016-06-28T14:47:55+02:00"}
{"level":"error","msg":"Failed to start container: inappropriate ioctl for device","time":"2016-06-28T14:47:55+02:00"}
{"level":"info","msg":"Removing container a97bd2257cc14601aacdab35f7971c4a704b577a76db7d1005cdb1a02ebd310a...","time":"2016-06-28T14:47:55+02:00"}
```