### PR TITLE
Use logs with fields

### DIFF
--- a/handler/handler.go
+++ b/handler/handler.go
@@ -197,6 +197,8 @@ func (c *Conplicity) LaunchDuplicity(cmd []string, binds []string) (state docker
 	state = container.State
 	stdout = stdoutBuffer.String()
 
+	log.Debug(stdout)
+
 	return
 }
 

--- a/providers/default.go
+++ b/providers/default.go
@@ -18,7 +18,9 @@ func (*DefaultProvider) GetName() string {
 
 // PrepareBackup sets up the data before backup
 func (p *DefaultProvider) PrepareBackup() error {
-	log.Infof("Provider %v does not implement a prepare method", p.GetName())
+	log.WithFields(log.Fields{
+		"provider": p.GetName(),
+	}).Debug("Provider does not implement a prepare method")
 	return nil
 }
 


### PR DESCRIPTION
```shell
$ conplicity 
INFO[0000] Starting backup...                           
INFO[0000] Ignoring volume                               reason=unnamed volume=156c8726b0d88c3b60066f8314279f5c49b9db51f405542491b25b49984a4e6e
INFO[0000] Ignoring volume                               reason=unnamed volume=c2b3637266cf2b3cdbfdae8ea1842c88e4cd60e245966243100a2aa61e442348
INFO[0000] Detecting provider                            volume=mydata
INFO[0000] Found provider                                provider=Default volume=mydata
INFO[0000] Creating duplicity container                  driver=local mountpoint=/var/lib/docker/volumes/mydata/_data volume=mydata
Command line error: One of the arguments must be an URL.  Examples of URL strings are
"scp://user@host.net:1234/path" and "file:///usr/local".  See the man
page for more information.
Enter 'duplicity --help' for help screen.
INFO[0000] Removing container                            container=7907912ea8fea1127b695950f7fb451c57979869aa7d7e3f6d353c4e49278927
ERRO[0003]                                               msg=Failed to retrieve last backup info for volume mydata : Failed to parse Duplicity output for last full backup date of mydata
INFO[0006] End backup...                                
```

And with json output:

```json
$ conplicity -j >/dev/null 
{"level":"info","msg":"Starting backup...","time":"2016-06-28T15:16:21+02:00"}
{"level":"info","msg":"Ignoring volume","reason":"unnamed","time":"2016-06-28T15:16:21+02:00","volume":"0da5c2077109383d537f265836d9aa44086e67711f8cbd1759150c88d9fdb478"}
{"level":"info","msg":"Detecting provider","time":"2016-06-28T15:16:22+02:00","volume":"mydata"}
{"level":"info","msg":"Found provider","provider":"Default","time":"2016-06-28T15:16:22+02:00","volume":"mydata"}
{"driver":"local","level":"info","mountpoint":"/var/lib/docker/volumes/mydata/_data","msg":"Creating duplicity container","time":"2016-06-28T15:16:22+02:00","volume":"mydata"}
{"fields.msg":"Failed to start container: inappropriate ioctl for device","level":"error","msg":"","time":"2016-06-28T15:16:22+02:00"}
{"container":"12e4131de7a0a74965cc61419c792d1e6718ea2f5403653420711619b18ebd04","level":"info","msg":"Removing container","time":"2016-06-28T15:16:22+02:00"}
{"fields.msg":"Failed to start container: inappropriate ioctl for device","level":"error","msg":"","time":"2016-06-28T15:16:22+02:00"}
{"fields.msg":"Failed to retrieve last backup info for volume mydata : Failed to parse Duplicity output for last full backup date of mydata","level":"error","msg":"","time":"2016-06-28T15:16:22+02:00"}
{"fields.msg":"Failed to backup volume mydata: Failed to parse Duplicity output for last full backup date of mydata","level":"error","msg":"","time":"2016-06-28T15:16:22+02:00"}
{"fields.msg":"Failed to process volume mydata: Failed to parse Duplicity output for last full backup date of mydata","level":"error","msg":"","time":"2016-06-28T15:16:22+02:00"}
{"level":"info","msg":"End backup...","time":"2016-06-28T15:16:23+02:00"}
```